### PR TITLE
Remove related views when button is removed from superview

### DIFF
--- a/Example/Tests/JJFloatingActionButtonSpec.swift
+++ b/Example/Tests/JJFloatingActionButtonSpec.swift
@@ -345,6 +345,21 @@ class JJFloatingActionButtonSpec: QuickSpec {
                             }
                         }
                     }
+
+                    context("and is removed from superview") {
+                        beforeEach {
+                            actionButton.removeFromSuperview()
+                        }
+
+                        it("removes related views from superview") {
+                            expect(actionButton.overlayView.superview).to(beNil())
+                            expect(actionButton.itemContainerView.superview).to(beNil())
+                        }
+
+                        it("closes") {
+                            expect(actionButton.buttonState).toEventually(equal(.closed))
+                        }
+                    }
                 }
 
                 context("and is opened and closed") {
@@ -430,6 +445,21 @@ class JJFloatingActionButtonSpec: QuickSpec {
                             expect(actionCount).toEventually(equal(1))
                         }
                     }
+
+                    context("and is removed from superview") {
+                        beforeEach {
+                            actionButton.removeFromSuperview()
+                        }
+
+                        it("removes related views from superview") {
+                            expect(actionButton.overlayView.superview).to(beNil())
+                            expect(actionButton.itemContainerView.superview).to(beNil())
+                        }
+
+                        it("closes") {
+                            expect(actionButton.buttonState).toEventually(equal(.closed))
+                        }
+                    }
                 }
 
                 context("and is closed animated") {
@@ -444,6 +474,21 @@ class JJFloatingActionButtonSpec: QuickSpec {
 
                     it("has eventually state closed") {
                         expect(actionButton.buttonState).toEventually(equal(.closed))
+                    }
+
+                    context("and is removed from superview") {
+                        beforeEach {
+                            actionButton.removeFromSuperview()
+                        }
+
+                        it("removes related views from superview") {
+                            expect(actionButton.overlayView.superview).to(beNil())
+                            expect(actionButton.itemContainerView.superview).to(beNil())
+                        }
+
+                        it("closes") {
+                            expect(actionButton.buttonState).toEventually(equal(.closed))
+                        }
                     }
                 }
 

--- a/Sources/JJFloatingActionButton+Animation.swift
+++ b/Sources/JJFloatingActionButton+Animation.swift
@@ -116,6 +116,18 @@ import UIKit
     }
 }
 
+internal extension JJFloatingActionButton {
+    func removeRelatedViewsFromSuperview() {
+        if overlayView.superview != nil {
+            overlayView.removeFromSuperview()
+        }
+
+        if itemContainerView.superview != nil {
+            itemContainerView.removeFromSuperview()
+        }
+    }
+}
+
 // MARK: - Animation State
 
 fileprivate extension JJFloatingActionButton {

--- a/Sources/JJFloatingActionButton.swift
+++ b/Sources/JJFloatingActionButton.swift
@@ -399,6 +399,16 @@ extension JJFloatingActionButton {
         updateDynamicConstraints()
         super.updateConstraints()
     }
+
+    /// Tells the view that its superview changed.
+    ///
+    public override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        if superview == nil {
+            close(animated: false)
+            removeRelatedViewsFromSuperview()
+        }
+    }
 }
 
 // MARK: - Setup


### PR DESCRIPTION
This fixes #223 

When the action button is removed from superview while it is open the overlay view and the action items are now removed from superview as well.